### PR TITLE
fixed the broken shaders

### DIFF
--- a/src/main/resources/assets/minecraft/shaders/post/bits.json
+++ b/src/main/resources/assets/minecraft/shaders/post/bits.json
@@ -1,0 +1,17 @@
+{
+    "targets": [
+        "swap"
+    ],
+    "passes": [
+        {
+            "name": "bits_fix",
+            "intarget": "minecraft:main",
+            "outtarget": "swap"
+        },
+        {
+            "name": "blit",
+            "intarget": "swap",
+            "outtarget": "minecraft:main"
+        }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/post/blur.json
+++ b/src/main/resources/assets/minecraft/shaders/post/blur.json
@@ -1,0 +1,43 @@
+{
+    "targets": [
+        "0",
+        "1"
+    ],
+    "passes": [
+        {
+            "name": "blur_fix",
+            "intarget": "minecraft:main",
+            "outtarget": "0",
+            "uniforms": [
+                {
+                    "name": "BlurDir",
+                    "values": [ 1.0, 0.0 ]
+                },
+                {
+                    "name": "Radius",
+                    "values": [ 20.0 ]
+                }
+            ]
+        },
+        {
+            "name": "blur_fix",
+            "intarget": "0",
+            "outtarget": "1",
+            "uniforms": [
+                {
+                    "name": "BlurDir",
+                    "values": [ 0.0, 1.0 ]
+                },
+                {
+                    "name": "Radius",
+                    "values": [ 20.0 ]
+                }
+            ]
+        },
+        {
+            "name": "blit",
+            "intarget": "1",
+            "outtarget": "minecraft:main"
+        }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/post/flip.json
+++ b/src/main/resources/assets/minecraft/shaders/post/flip.json
@@ -1,0 +1,17 @@
+{
+    "targets": [
+        "swap"
+    ],
+    "passes": [
+        {
+            "name": "flip_fix",
+            "intarget": "minecraft:main",
+            "outtarget": "swap"
+        },
+        {
+            "name": "blit",
+            "intarget": "swap",
+            "outtarget": "minecraft:main"
+        }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/post/outline.json
+++ b/src/main/resources/assets/minecraft/shaders/post/outline.json
@@ -1,0 +1,17 @@
+{
+    "targets": [
+        "swap"
+    ],
+    "passes": [
+        {
+            "name": "outline",
+            "intarget": "minecraft:main",
+            "outtarget": "swap"
+        },
+        {
+            "name": "blit",
+            "intarget": "swap",
+            "outtarget": "minecraft:main"
+        }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/bits_fix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/bits_fix.json
@@ -1,0 +1,21 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "one",
+        "dstrgb": "zero"
+    },
+    "vertex": "sobel",
+    "fragment": "bits",
+    "attributes": [ "Position" ],
+    "samplers": [
+        { "name": "DiffuseSampler" }
+    ],
+    "uniforms": [
+        { "name": "ProjMat",          "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "InSize",           "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "OutSize",          "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "Resolution",       "type": "float",     "count": 1,  "values": [ 4.0 ] },
+        { "name": "Saturation",       "type": "float",     "count": 1,  "values": [ 1.5 ] },
+        { "name": "MosaicSize",       "type": "float",     "count": 1,  "values": [ 8.0 ] }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/blur_fix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/blur_fix.json
@@ -1,0 +1,20 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "one",
+        "dstrgb": "1-srcalpha"
+    },
+    "vertex": "sobel",
+    "fragment": "blur",
+    "attributes": [ "Position" ],
+    "samplers": [
+        { "name": "DiffuseSampler" }
+    ],
+    "uniforms": [
+        { "name": "ProjMat",     "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "InSize",      "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "OutSize",     "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "BlurDir",     "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "Radius",      "type": "float",     "count": 1,  "values": [ 5.0 ] }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/flip_fix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/flip_fix.json
@@ -1,0 +1,20 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "one",
+        "dstrgb": "1-srcalpha"
+    },
+    "vertex": "flip",
+    "fragment": "blit",
+    "attributes": [ "Position" ],
+    "samplers": [
+        { "name": "DiffuseSampler" }
+    ],
+    "uniforms": [
+        { "name": "ProjMat",    "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "InSize",     "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "OutSize",    "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "ScreenSize", "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "ColorModulate", "type": "float",     "count": 4,  "values": [ 1.0, 1.0, 1.0, 1.0 ] }
+    ]
+}


### PR DESCRIPTION
the new programs are suffixed _fix as overwriting existing vanilla programs can cause other issues with existing shaders (eg the spider post shader also uses the blur program, so touching blur may cause issues with spider)

Heres what i remember the problems being from when i fixed them for [my mod](https://modrinth.com/mod/souper-secret-settings):
- the shader "outline" was using an outdated syntax where the main frame buffer was called "final" instead of "minecraft:main", this is probably what it was back in 1.8, and some time between someone updated *most* of the shaders, but missed outline
- the shader "flip" had a really weird bug that causes the sky to dissapear due to the fragment shader not setting the alpha value correctly by doing `fragcolor = col` instead of `fragcolor = vec4(col.rgb, 1.0)` - this can be fixed in two different ways, either the fragment shader can be changed, or the dstrgb field in the program file can be changed. Changing the fragment shader of a vanilla shader is a good way to cause even more problems though, so i fiixed the dstrgb instead
- the shader "blur" had a problem where using a program other than "blit" to write to minecraft:main as the final step would mess up the vignette on fancy graphics. making the screen go black unless you pressed F1. it also had the same issue as "flip"
- the shader "bits" was technically not broken, however it had the srcrgb and dstrgb setup in such a way that meant it messed up the framebuffer in a way that can sometimes cause issues with anything else using the framebuffer