### PR TITLE
similar to the other namespace bug, when loading textures in a post s…

### DIFF
--- a/src/main/java/com/mclegoman/perspective/mixin/PerspectiveMixinPlugin.java
+++ b/src/main/java/com/mclegoman/perspective/mixin/PerspectiveMixinPlugin.java
@@ -28,7 +28,12 @@ public class PerspectiveMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (mixinClassName.equals("com.mclegoman.perspective.mixin.client.shaders.PerspectiveShaderNamespaceFix")) return !(FabricLoader.getInstance().isModLoaded("souper_secret_settings") || FabricLoader.getInstance().isModLoaded("architectury") || FabricLoader.getInstance().isModLoaded("satin"));
+        if (mixinClassName.equals("com.mclegoman.perspective.mixin.client.shaders.PerspectiveShaderNamespaceFix")) {
+            return !(FabricLoader.getInstance().isModLoaded("souper_secret_settings") || FabricLoader.getInstance().isModLoaded("architectury") || FabricLoader.getInstance().isModLoaded("satin"));
+        }
+        if (mixinClassName.equals("com.mclegoman.perspective.mixin.client.shaders.PerspectiveShaderTextureNamespaceFix")) {
+            return !(FabricLoader.getInstance().isModLoaded("souper_secret_settings"));
+        }
         else return true;
     }
 

--- a/src/main/java/com/mclegoman/perspective/mixin/client/shaders/PerspectiveShaderTextureNamespaceFix.java
+++ b/src/main/java/com/mclegoman/perspective/mixin/client/shaders/PerspectiveShaderTextureNamespaceFix.java
@@ -1,0 +1,28 @@
+/*
+
+ */
+
+package com.mclegoman.perspective.mixin.client.shaders;
+
+import net.minecraft.client.gl.PostEffectProcessor;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(priority = 10000, value = PostEffectProcessor.class)
+public class PerspectiveShaderTextureNamespaceFix {
+    @Redirect(method = "parsePass", at = @At(value = "NEW", target = "(Ljava/lang/String;)Lnet/minecraft/util/Identifier;"))
+    private static Identifier perspective$loadTexture(String id) {
+        return perspective$get(id);
+    }
+
+    private static Identifier perspective$get(String id) {
+        if (id.contains(":")) {
+            String[] shader = id.substring(16).split(":");
+            return new Identifier(shader[0], "textures/effect/" + shader[1]);
+        } else {
+            return new Identifier(id);
+        }
+    }
+}

--- a/src/main/resources/mclegoman-perspective.mixins.json
+++ b/src/main/resources/mclegoman-perspective.mixins.json
@@ -14,6 +14,7 @@
     "client.shaders.PerspectivePostProcessor",
     "client.shaders.PerspectiveShaderNamespaceFix",
     "client.shaders.PerspectiveShaderRenderer",
+    "client.shaders.PerspectiveShaderTextureNamespaceFix",
     "client.shaders.PerspectiveWorldRenderer",
     "client.textured_entity.PerspectiveAllayEntityRenderer",
     "client.textured_entity.PerspectiveArmorStandEntityRenderer",


### PR DESCRIPTION
similar to the other namespace bug, when loading textures in a post shader there is an oversight where the location would have to be in *minecraft*/textures/effect/<x>

interestingly, neither satin or architectury fix this, souper secret settings will do so in the next update

(see https://github.com/Nettakrim/Souper-Secret-Settings/blob/main/src/main/resources/resourcepacks/expanded_shaders/assets/expanded_shaders/shaders/post/autumnal.json for an example of texture loading being used)

funnily enough `textures/effect/` is the same length as `shaders/program/`, so the substring is still 16